### PR TITLE
Pass ranges of matches to custom Matcher implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ var urls = [URL]()
 var titles = [String]()
 
 text.scan(using: [
-    Matcher(identifiers: ["url: "], terminators: ["\n", .end]) {
-        let string = String($0)
+    Matcher(identifiers: ["url: "], terminators: ["\n", .end]) { match, range in
+        let string = String(match)
         let url = URL(string: string)
         url.flatMap { urls.append($0) }
     },
-    Matcher(identifiers: ["title: "], terminators: ["\n", .end]) {
-        let string = String($0)
+    Matcher(identifiers: ["title: "], terminators: ["\n", .end]) { match, range in
+        let string = String(match)
         titles.append(string)
     }
 ])

--- a/Tests/SweepTests/SweepTests.swift
+++ b/Tests/SweepTests/SweepTests.swift
@@ -99,23 +99,25 @@ final class SweepTests: XCTestCase {
     }
 
     func testMultipleMatchers() {
-        let string = "Some text <First> some other text [Second]."
-        var matches = (
-            a: [Substring](),
-            b: [Substring]()
-        )
+        let string = "Some text <First> some other text [[Second]]."
+        var matches = (a: [Substring](), b: [Substring]())
+        var ranges = (a: [ClosedRange<String.Index>](), b: [ClosedRange<String.Index>]())
 
         string.scan(using: [
-            Matcher(identifier: "<", terminator: ">") {
-                matches.a.append($0)
+            Matcher(identifier: "<", terminator: ">") { match, range in
+                matches.a.append(match)
+                ranges.a.append(range)
             },
-            Matcher(identifier: "[", terminator: "]") {
-                matches.b.append($0)
+            Matcher(identifier: "[[", terminator: "]]") { match, range in
+                matches.b.append(match)
+                ranges.b.append(range)
             }
         ])
 
         XCTAssertEqual(matches.a, ["First"])
+        XCTAssertEqual(ranges.a.map { string[$0] }, ["<First>"])
         XCTAssertEqual(matches.b, ["Second"])
+        XCTAssertEqual(ranges.b.map { string[$0] }, ["[[Second]]"])
     }
 
     func testAllTestsRunOnLinux() {


### PR DESCRIPTION
When the custom `Matcher` API is used, the range of each match found when scanning a string is now passed to each matcher’s handler. That enables more customizability, for example to be able to later replace all found substrings within the original string.

The `scan` implementation was also a bit streamlined to accommodate this change, since the identifier matched against now needs to be kept track of.