### PR TITLE
Fix matching against the start of a string

### DIFF
--- a/Sources/Sweep/Sweep.swift
+++ b/Sources/Sweep/Sweep.swift
@@ -217,6 +217,12 @@ public extension StringProtocol where SubSequence == Substring {
                         guard index == startIndex else {
                             continue
                         }
+
+                        guard !identifier.string.isEmpty else {
+                            let range = index...index
+                            activeSessions.append((matcher, identifier, range))
+                            return false
+                        }
                     }
 
                     if identifier.string.first == self[index] {

--- a/Tests/SweepTests/SweepTests.swift
+++ b/Tests/SweepTests/SweepTests.swift
@@ -20,10 +20,22 @@ final class SweepTests: XCTestCase {
         XCTAssertEqual(matches, ["Scanned"])
     }
 
+    func testMatchingStartOfStringWithStartIdentifier() {
+        let string = "<Scanned> Some text."
+        let matches = string.substrings(between: .start, and: ">")
+        XCTAssertEqual(matches, ["<Scanned"])
+    }
+
     func testMatchingEndOfString() {
         let string = "Some text <Scanned>"
         let matches = string.substrings(between: "<", and: ">")
         XCTAssertEqual(matches, ["Scanned"])
+    }
+
+    func testMatchingEndOfStringWithEndTerminator() {
+        let string = "Some text <Scanned>"
+        let matches = string.substrings(between: "<", and: .end)
+        XCTAssertEqual(matches, ["Scanned>"])
     }
 
     func testMatchingMultipleSegments() {
@@ -130,7 +142,9 @@ extension SweepTests: LinuxTestable {
         return [
             ("testBasicScanning", testBasicScanning),
             ("testMatchingStartOfString", testMatchingStartOfString),
+            ("testMatchingStartOfStringWithStartIdentifier", testMatchingStartOfStringWithStartIdentifier),
             ("testMatchingEndOfString", testMatchingEndOfString),
+            ("testMatchingEndOfStringWithEndTerminator", testMatchingEndOfStringWithEndTerminator),
             ("testMatchingMultipleSegments", testMatchingMultipleSegments),
             ("testMatchingBackToBackSegments", testMatchingBackToBackSegments),
             ("testMultipleIdentifiersAndTerminators", testMultipleIdentifiersAndTerminators),


### PR DESCRIPTION
This patch fixes a bug that would cause matches against the start of a string (without a specific prefix) to fail. It also adds tests to cover both that case and the case of matching against the `.end` terminator.