### PR TITLE
Enable matchers to be single-use only

### DIFF
--- a/Tests/SweepTests/SweepTests.swift
+++ b/Tests/SweepTests/SweepTests.swift
@@ -132,6 +132,24 @@ final class SweepTests: XCTestCase {
         XCTAssertEqual(ranges.b.map { string[$0] }, ["[[Second]]"])
     }
 
+    func testDisallowingMultipleMatches() {
+        let string = "Some text <First> some other text <Second>, <Third>."
+        var matches = [Substring]()
+
+        string.scan(using: [
+            Matcher(
+                identifier: "<",
+                terminator: ">",
+                allowMultipleMatches: false,
+                handler: { match, _ in
+                    matches.append(match)
+                }
+            )
+        ])
+
+        XCTAssertEqual(matches, ["First"])
+    }
+
     func testAllTestsRunOnLinux() {
         verifyAllTestsRunOnLinux()
     }
@@ -154,7 +172,8 @@ extension SweepTests: LinuxTestable {
             ("testIgnoringEmptyMatch", testIgnoringEmptyMatch),
             ("testHTMLScanning", testHTMLScanning),
             ("testMarkdownScanning", testMarkdownScanning),
-            ("testMultipleMatchers", testMultipleMatchers)
+            ("testMultipleMatchers", testMultipleMatchers),
+            ("testDisallowingMultipleMatches", testDisallowingMultipleMatches)
         ]
     }
 }


### PR DESCRIPTION
This change makes it possible to create matchers that only match a single identifier/terminator combo, and get discarded after that.

This, combined with a new check to make sure that for each iteration, there’s at least one eligible matcher still remaining - can lead to some big performance improvements if only a single piece of data is being scanned for.