### PR TITLE
Add new APIs for scanning for a single substring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.build
 /Packages
 /*.xcodeproj
+.swiftpm

--- a/Sources/Sweep/Sweep.swift
+++ b/Sources/Sweep/Sweep.swift
@@ -130,6 +130,34 @@ public extension Matcher {
 }
 
 public extension StringProtocol where SubSequence == Substring {
+    /// Scan this string for a single substring that appears between
+    /// a single identifier and terminator, and return any found match.
+    func firstSubstring(between identifier: Identifier,
+                        and terminator: Terminator) -> Substring? {
+        return firstSubstring(between: [identifier],
+                              and: [terminator])
+    }
+
+    /// Scan this string for a single substring that appears between
+    /// a set of identifiers and terminators, and return any found match.
+    func firstSubstring(between identifiers: [Identifier],
+                        and terminators: [Terminator]) -> Substring? {
+        var match: Substring?
+
+        scan(using: [
+            Matcher(
+                identifiers: identifiers,
+                terminators: terminators,
+                allowMultipleMatches: false,
+                handler: { substring, _ in
+                    match = substring
+                }
+            )
+        ])
+
+        return match
+    }
+
     /// Scan this string for substrings appearing between a single
     /// identifier and terminator, and return all matches.
     func substrings(between identifier: Identifier,

--- a/Tests/SweepTests/SweepTests.swift
+++ b/Tests/SweepTests/SweepTests.swift
@@ -150,6 +150,18 @@ final class SweepTests: XCTestCase {
         XCTAssertEqual(matches, ["First"])
     }
 
+    func testScanningForSingleSubstring() {
+        let string = "Some text <First> some other text <Second>, <Third>."
+        let match = string.firstSubstring(between: "<", and: ">")
+        XCTAssertEqual(match, "First")
+    }
+
+    func testScanningForSingleSubstringWithMultipleIdentifiers() {
+        let string = "Some text <First> some other text [Second], <Third>."
+        let match = string.firstSubstring(between: ["<", "["], and: [">", "]"])
+        XCTAssertEqual(match, "First")
+    }
+
     func testAllTestsRunOnLinux() {
         verifyAllTestsRunOnLinux()
     }
@@ -173,7 +185,9 @@ extension SweepTests: LinuxTestable {
             ("testHTMLScanning", testHTMLScanning),
             ("testMarkdownScanning", testMarkdownScanning),
             ("testMultipleMatchers", testMultipleMatchers),
-            ("testDisallowingMultipleMatches", testDisallowingMultipleMatches)
+            ("testDisallowingMultipleMatches", testDisallowingMultipleMatches),
+            ("testScanningForSingleSubstring", testScanningForSingleSubstring),
+            ("testScanningForSingleSubstringWithMultipleIdentifiers", testScanningForSingleSubstringWithMultipleIdentifiers)
         ]
     }
 }


### PR DESCRIPTION
This change introduces new APIs for scanning for just a single substring and immediately returning any result found. Using this API will be a lot faster for use cases that only require a single match, since it won’t require iterating through the rest of the string once a match was found.